### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,23 +119,35 @@ To make the most out of the Bitcoin Signet Docker image, here are some essential
    ```bash
    docker exec -it bitcoin-signet-instance /bin/bash
    ```
+   
+8. **View sync logs of a container**:
+   
+   ```bash
+   docker exec -it bitcoin-signet-instance bash
+   cd /root/.bitcoin/signet
+   tail debug.log -f
+   ``` 
+   If most of your logs are composed of `UpdateTip: new best=...` messages, it means that your node is syncing with the network.
+   
+   If after a while you see `Saw new header hash=...` logs, it means that your node is fully synced!
 
-8. **Pull the latest version of the image**:
-
+9. **Pull the latest version of the image**:
+    
    ```bash
    docker pull bitcoin-signet
    ```
 
-9. **Remove an image**:
+10. **Remove an image**:
 
-   ```bash
-   docker rmi bitcoin-signet
-   ```
+     ```bash
+     docker rmi bitcoin-signet
+     ```
 
-10. **View all Docker images**:
-    ```bash
-    docker images
-    ```
+11. **View all Docker images**:
+
+     ```bash
+     docker images
+     ```
 
 Remember to replace `bitcoin-signet-instance` with the name of your container if you've named it differently.
 


### PR DESCRIPTION
Since **`docker logs bitcoin-signet-client`** shows only setup messages like below, many people wonder how to check Signet node sync status

```
install_done file not found, running install.sh.
Generate or import keyset
Imported signetchallange and privkey being used.
PRIVKEY=
SIGNETCHALLENGE= 512102653734c749d5f7227d9576b3305574fd3b0efdeaa64f3d500f121bf235f0a43151ae
Generate bitcoind configuration
Setup Signet
Bitcoin Core starting
{
  "name": "citrea",
  "warning": "Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future."
}
Infinate loop
Error: Cannot obtain a lock on data directory /root/.bitcoin/signet. Bitcoin Core is probably already running.
get magic
```

This pull request adds some clarity to README documentation. No other documentation was modified.